### PR TITLE
Add devShell preset for Phoenix projects

### DIFF
--- a/parts/all-parts.nix
+++ b/parts/all-parts.nix
@@ -6,5 +6,6 @@
     ./devshell.nix
     ./language-server.nix
     ./packages.nix
+    ./phoenix.nix
   ];
 }

--- a/parts/phoenix.nix
+++ b/parts/phoenix.nix
@@ -1,0 +1,43 @@
+{
+  config,
+  lib,
+  flake-parts-lib,
+  ...
+}: let
+  inherit
+    (lib)
+    mkEnableOption
+    mkMerge
+    mkIf
+    ;
+  inherit
+    (flake-parts-lib)
+    mkPerSystemOption
+    mkSubmoduleOptions
+    ;
+in {
+  options = {
+    perSystem = mkPerSystemOption (_: {
+      _file = ./phoenix.nix;
+
+      options.beamWorkspace.devShell = mkSubmoduleOptions {
+        phoenix = mkEnableOption "phoenix framework";
+      };
+    });
+  };
+
+  config = {
+    perSystem = {
+      config,
+      pkgs,
+      ...
+    }: let
+      cfg = config.beamWorkspace.devShell;
+    in {
+      beamWorkspace.devShell.packages = mkMerge [
+        (mkIf pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [CoreServices]))
+        (mkIf pkgs.stdenv.isLinux [pkgs.inotify-tools])
+      ];
+    };
+  };
+}

--- a/templates/phoenix/flake.nix
+++ b/templates/phoenix/flake.nix
@@ -23,6 +23,7 @@
           enable = true;
           devShell.languageServers.elixir = true;
           devShell.languageServers.erlang = false;
+          devShell.phoenix = true;
           versions = {
             elixir = "1.14.4-otp-25";
             erlang = "25.3.2";


### PR DESCRIPTION
- [X] Add opt-in Phoenix preset for devShell
- [X] Include Phoenix devShell preset in Phoenix flake template

Usage:
```nix
beamWorkspace.devShell.phoenix = true;
```

cc @khionu

Closes #3.