### PR TITLE
Elixir 1.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,8 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@v2
         with:
           diagnostic-endpoint: ""
-      - run: nix -L flake check ./dev
+      - run: nix -L flake check --all-systems
+      - run: nix -L flake check ./dev --all-systems
 
   packages:
     name: Build Packages

--- a/.justfile
+++ b/.justfile
@@ -5,8 +5,8 @@ add-elixir version:
 add-erlang version:
     nix run ./dev#add-otp-version {{ version }}
 check:
-    nix flake check
-    nix flake check ./dev
+    nix flake check --all-systems
+    nix flake check ./dev --all-systems
 doc:
   nix build .#optionsDoc
   cat ./result > docs/options.md

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ A complete example:
           enable = true;
           devShell.languageServers.elixir = true;
           versions = {
-            elixir = "1.15.7";
+            elixir = "1.16.0";
             erlang = "26.2";
           };
         };
@@ -138,7 +138,7 @@ setting `perSystem.beamWorkspace.devShell.enable = false;`
             #
             # Everything after the first hyphen is stripped and handled according
             # to the defined erlang version instead.
-            elixir = "1.15.7";
+            elixir = "1.16.0";
             erlang = "26.2";
           };
         };
@@ -206,7 +206,7 @@ If you are a Nix user, this is already automated:
 
 ```shell
 nix develop ./dev
-just add-elixir 1.15.7
+just add-elixir 1.16.0
 just add-erlang 26.2
 ```
 

--- a/data/elixir.json
+++ b/data/elixir.json
@@ -52,6 +52,7 @@
   "1.15.5": "1b9mxlb0x301lmjd5wvhw23vliv265wx384bpd76phk0grx73kfq",
   "1.15.6": "19vhci9dxdm3sb937ba3np5gadgfcsnrnc30n17c4xk556mk473r",
   "1.15.7": "0yfp16fm8v0796f1rf1m2r0m2nmgj3qr7478483yp1x5rk4xjrz8",
+  "1.16.0": "01sdmnbyz2r780437h160ka7zb605b08w9ar031xikbwgnjx7kcw",
   "1.2.0": "1rhj4sgn4czw12k69ln62lvlp96ak9fhjdz21gzrc8hzr9gfz5s1",
   "1.2.1": "1n5j7xb8bc6pqayb2pmhjf9dn7smqlnqbrngjdk0qajjfyq23d1z",
   "1.2.2": "0d6m1bf6gcn5jx6z61xs0aknyd4k5ayas36axxfi4aiib98jvkmb",

--- a/dev/example/.tool-versions
+++ b/dev/example/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.15.7-otp-26
+elixir 1.16.0-otp-26
 erlang 26.2

--- a/dev/example/flake.nix
+++ b/dev/example/flake.nix
@@ -25,7 +25,7 @@
           devShell.languageServers.erlang = false;
           flakePackages = true;
           versions = {
-            elixir = "1.15.7-otp-26";
+            elixir = "1.16.0-otp-26";
             erlang = "26.2";
           };
           # versions.fromToolVersions = ./.tool-versions;

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,7 +9,7 @@ If you are a Nix user, this is already automated:
 
 ```shell
 nix develop ./dev
-just add-elixir 1.15.7
+just add-elixir 1.16.0
 just add-erlang 26.2
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -107,7 +107,7 @@ This approach is mutually exclusive with the syntax [described above](#explicitl
 
 ```
 # .toolversions
-elixir 1.15.7
+elixir 1.16.0
 erlang 26.2
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703637592,
-        "narHash": "sha256-8MXjxU0RfFfzl57Zy3OfXCITS0qWDNLzlBAdwxGZwfY=",
-        "owner": "nixos",
+        "lastModified": 1704008649,
+        "narHash": "sha256-rGPSWjXTXTurQN9beuHdyJhB8O761w1Zc5BqSSmHvoM=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cfc3698c31b1fb9cdcf10f36c9643460264d0ca8",
+        "rev": "d44d59d2b5bd694cd9d996fd8c51d03e3e9ba7f7",
         "type": "github"
       },
       "original": {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -80,7 +80,17 @@
     // (
       if elixirLanguageServer
       then {
-        elixir-ls = beamPkgs.elixir-ls.override {inherit elixir;};
+        elixir-ls = (beamPkgs.elixir-ls.override {inherit elixir;}).overrideAttrs (old: {
+          buildPhase =
+            # Elixir 1.16.0 or newer
+            if ((builtins.compareVersions elixir.version "1.16.0") != -1)
+            then ''
+              runHook preBuild
+              mix do compile --no-deps-check, elixir_ls.release2
+              runHook postBuild
+            ''
+            else old.buildPhase;
+        });
       }
       else {}
     )

--- a/local-parts/devshells.nix
+++ b/local-parts/devshells.nix
@@ -27,7 +27,7 @@
     devShells.example = let
       pkgSet = self.lib.mkPackageSet {
         inherit pkgs;
-        elixirVersion = "1.15.7";
+        elixirVersion = "1.16.0";
         erlangVersion = "26.2";
         elixirLanguageServer = true;
       };

--- a/templates/default/.tool-versions
+++ b/templates/default/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.15.6-otp-26
-erlang 26.1.2
+elixir 1.16.0-otp-26
+erlang 26.2

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -29,7 +29,7 @@
             languageServers.erlang = false;
           };
           versions = {
-            elixir = "1.15.7";
+            elixir = "1.16.0";
             erlang = "26.2";
           };
         };

--- a/templates/phoenix/.tool-versions
+++ b/templates/phoenix/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.15.6-otp-26
-erlang 26.1.2
+elixir 1.16.0-otp-26
+erlang 26.2

--- a/templates/phoenix/flake.nix
+++ b/templates/phoenix/flake.nix
@@ -30,7 +30,7 @@
             phoenix = true;
           };
           versions = {
-            elixir = "1.15.7";
+            elixir = "1.16.0";
             erlang = "26.2";
           };
         };


### PR DESCRIPTION
Depends on https://github.com/NixOS/nixpkgs/pull/276085 . As of 2023-12-22, derivation for `elixir-ls` appears to fail to build on 1.16, but support in the upstream project [appears to be forthcoming](https://github.com/elixir-lsp/elixir-ls/commit/ad3473c6ce388c1e6dcb042aea55205e0dc99616).