### PR TITLE
feat(ci): Enable MacOS M1 runners on GHA

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -30,7 +30,7 @@ jobs:
           echo "matrix=$(nix eval --json '.#lib.recentMatrix')" >> "$GITHUB_OUTPUT"
 
   packages:
-    name: Cache ${{ matrix.elixir }} on OTP ${{ matrix.erlang }}
+    name: Cache ${{ matrix.elixir }} on OTP ${{ matrix.erlang }} (${{ matrix.os }})
     needs: matrix
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     name: Build Packages
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-14, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -137,7 +137,7 @@
     pipe {
       elixir = recentElixirs;
       erlang = recentErlangs;
-      os = ["ubuntu-latest"];
+      os = ["macos-14" "ubuntu-latest"];
     } [
       lib.attrsets.cartesianProductOfSets
       (builtins.filter (set: versionCompatible set.elixir set.erlang))


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/